### PR TITLE
Deinterlace interlaced frames  / MPEG2-TS time-offset-position

### DIFF
--- a/kxmovie/KxMovieDecoder.m
+++ b/kxmovie/KxMovieDecoder.m
@@ -1029,6 +1029,10 @@ static BOOL isNetworkPath (NSString *path)
                                                 &gotframe,
                                                 &packet);
                 
+                if(_videoFrame->interlaced_frame) {
+                    avpicture_deinterlace((AVPicture*)_videoFrame, (AVPicture*)_videoFrame, _videoCodecCtx->pix_fmt, _videoCodecCtx->width, _videoCodecCtx->height);
+                }
+
                 if (len < 0) {
                     NSLog(@"decode video error, skip packet");
                     break;

--- a/kxmovie/KxMovieViewController.m
+++ b/kxmovie/KxMovieViewController.m
@@ -16,6 +16,7 @@
 #import "KxAudioManager.h"
 #import "KxMovieGLView.h"
 
+const int kFirstFrameTsNotSet = -1;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -82,10 +83,11 @@ static NSMutableDictionary * gHistory;
     NSData              *_currentAudioFrame;
     NSUInteger          _currentAudioFramePos;
     CGFloat             _moviePosition;
+    CGFloat             _firstFrameTs;
     BOOL                _disableUpdateHUD;
     NSInteger           _scheduledDecode;
     NSLock              *_scheduledLock;
-    NSTimeInterval      _startTime;    
+    NSTimeInterval      _startTime;
     BOOL                _fullscreen;
     BOOL                _hiddenHUD;
     BOOL                _fitMode;
@@ -122,6 +124,7 @@ static NSMutableDictionary * gHistory;
 }
 
 @property (readwrite) BOOL playing;
+@property (readonly) CGFloat actualMoviePosition;
 @end
 
 @implementation KxMovieViewController
@@ -148,6 +151,7 @@ static NSMutableDictionary * gHistory;
         
         _moviePosition = 0;
         _startTime = -1;
+        _firstFrameTs = kFirstFrameTsNotSet;
         self.wantsFullScreenLayout = YES;
         
         __weak KxMovieViewController *weakSelf = self;
@@ -848,7 +852,10 @@ static NSMutableDictionary * gHistory;
             for (KxMovieFrame *frame in frames)
                 if (frame.type == KxMovieFrameTypeVideo) {
                     [_videoFrames addObject:frame];
-                    _bufferedDuration += frame.duration;                    
+                    _bufferedDuration += frame.duration;
+                    if (_firstFrameTs == kFirstFrameTsNotSet) {
+                        _firstFrameTs = (int)frame.position;
+                    }
                 }
         }
     }
@@ -1020,9 +1027,9 @@ static NSMutableDictionary * gHistory;
     
     CGFloat duration = _decoder.duration;
     if (_progressSlider.state == UIControlStateNormal)
-        _progressSlider.value = _moviePosition / duration;
-    _progressLabel.text = formatTimeInterval(_moviePosition, NO);
-    _leftLabel.text = formatTimeInterval(duration - _moviePosition, YES);
+        _progressSlider.value = self.actualMoviePosition / duration;
+    _progressLabel.text = formatTimeInterval(self.actualMoviePosition, NO);
+    _leftLabel.text = formatTimeInterval(duration - self.actualMoviePosition, YES);
             
 #ifdef DEBUG
     _messageLabel.text = [NSString stringWithFormat:@"%d %d %d - %@ %@",
@@ -1083,6 +1090,7 @@ static NSMutableDictionary * gHistory;
     _bufferedDuration = 0;
     
     position = MIN(_decoder.duration - 1, MAX(0, position));
+    position += _firstFrameTs;
     
     @synchronized (_decoder) {
         _decoder.position = position;
@@ -1320,6 +1328,10 @@ static NSMutableDictionary * gHistory;
             }
         }
     }
+}
+
+-(CGFloat)actualMoviePosition {
+    return _moviePosition - _firstFrameTs;
 }
 
 @end


### PR DESCRIPTION
MPEG2 videos can be interlaced. 
If not de-interlaced at playback time, this can produce some artifacts (stripes appear on the video).
These extra few lines cater with this issue.
![before](https://f.cloud.github.com/assets/403701/66329/e9decb6a-5ea0-11e2-8ace-0ae9b6c06bf9.png)
![after](https://f.cloud.github.com/assets/403701/66331/ef31b582-5ea0-11e2-8558-e7296b3c24a4.png)
