### PR TITLE
Build FFmpeg from release/1.1 tag

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,7 @@ FFMPEG_BUILD_ARGS_SIM = [
 '--cpu=i386',
 "--extra-ldflags='-arch i386'",
 "--extra-cflags='-arch i386'",
+'--disable-asm',
 ]
 
 FFMPEG_BUILD_ARGS_ARMV7 = [
@@ -43,6 +44,7 @@ FFMPEG_BUILD_ARGS_ARMV7 = [
 '--disable-armv6',
 '--disable-armv6t2',
 '--disable-vfp',
+'--disable-asm',
 ]
 
 FFMPEG_BUILD_ARGS_ARMV7S = [
@@ -59,6 +61,7 @@ FFMPEG_BUILD_ARGS_ARMV7S = [
 '--disable-armv6',
 '--disable-armv6t2',
 '--disable-vfp',
+'--disable-asm',
 ]
 
 FFMPEG_BUILD_ARGS = [

--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ FFMPEG_BUILD_ARGS_ARMV7 = [
 '--disable-armv5te',
 '--disable-armv6',
 '--disable-armv6t2',
-'--disable-armvfp',
+'--disable-vfp',
 ]
 
 FFMPEG_BUILD_ARGS_ARMV7S = [
@@ -58,7 +58,7 @@ FFMPEG_BUILD_ARGS_ARMV7S = [
 '--disable-armv5te',
 '--disable-armv6',
 '--disable-armv6t2',
-'--disable-armvfp',
+'--disable-vfp',
 ]
 
 FFMPEG_BUILD_ARGS = [

--- a/kxmovie.xcodeproj/project.pbxproj
+++ b/kxmovie.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4E5763CC16E1515500E6F6EE /* libiconv.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E5763CB16E1515500E6F6EE /* libiconv.2.dylib */; };
 		87E793FD16390F6D000A0848 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87E793FC16390F6D000A0848 /* UIKit.framework */; };
 		87E793FF16390F6D000A0848 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87E793FE16390F6D000A0848 /* Foundation.framework */; };
 		87E7940116390F6D000A0848 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87E7940016390F6D000A0848 /* CoreGraphics.framework */; };
@@ -61,6 +62,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4E5763CB16E1515500E6F6EE /* libiconv.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.2.dylib; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/usr/lib/libiconv.2.dylib; sourceTree = DEVELOPER_DIR; };
 		87E793F816390F6D000A0848 /* KxMovieExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KxMovieExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		87E793FC16390F6D000A0848 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		87E793FE16390F6D000A0848 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -106,6 +108,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4E5763CC16E1515500E6F6EE /* libiconv.2.dylib in Frameworks */,
 				87E7945116391BC1000A0848 /* libz.dylib in Frameworks */,
 				87E7944A16391B9E000A0848 /* libavcodec.a in Frameworks */,
 				87E7944C16391B9E000A0848 /* libavformat.a in Frameworks */,
@@ -169,6 +172,7 @@
 				87E7944716391B9E000A0848 /* libavutil.a */,
 				87E7944816391B9E000A0848 /* libswresample.a */,
 				87E7944916391B9E000A0848 /* libswscale.a */,
+				4E5763CB16E1515500E6F6EE /* libiconv.2.dylib */,
 				87E7945016391BC1000A0848 /* libz.dylib */,
 				87E793FC16390F6D000A0848 /* UIKit.framework */,
 				87E793FE16390F6D000A0848 /* Foundation.framework */,


### PR DESCRIPTION
This branch updates the FFmpeg submodule to use the latest commit in the release/1.1 branch, and updates Rakefile, gas-preprocessor.pl, and the KxMovieExample project to build correctly with those sources.

See https://github.com/kolyvan/kxmovie/issues/25 for more details about what was changed and why.
